### PR TITLE
chore: use github output format for ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -467,7 +467,11 @@ ruff: $(AQUA_ROOT_DIR)/.installed ## Runs the ruff linter.
 	if [ "$${files}" == "" ]; then \
 		exit 0; \
 	fi; \
-	ruff check $${files}
+	if [ "$(OUTPUT_FORMAT)" == "github" ]; then \
+		ruff check --output-format=github $${files}; \
+	else \
+		ruff check $${files}; \
+	fi
 
 .PHONY: textlint
 textlint: node_modules/.installed $(AQUA_ROOT_DIR)/.installed ## Runs the textlint linter.


### PR DESCRIPTION
**Description:**

Use the `github` output format for `ruff` when on GitHub Actions.

**Related Issues:**

Fixes #20 

**Checklist:**

- [ ] Review the [`CONTRIBUTING.md`](../blob/main/CONTRIBUTING.md) documentation.
- [ ] Add a reference to a related issue in the repository.
- [ ] Add a description of the changes proposed in the pull request.
- [ ] Add unit tests if applicable.
- [ ] Update documentation if applicable.
- [ ] Add a note in the [`CHANGELOG.md`](../blob/main/CHANGELOG.md) if applicable.
